### PR TITLE
Support clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub(crate) const MAX_LOAD_FACTOR: f32 = 1.1;
 ///
 /// L and R are the left and right types being mapped to eachother. LH and RH are the hash builders
 /// used to hash the left keys and right keys. B is the bitfield used to store neighbourhoods.
+#[derive(Clone)]
 pub struct BiMap<L, R, LH = RandomState, RH = RandomState, B = DefaultBitField> {
     /// The number of pairs inside the map
     len: usize,


### PR DESCRIPTION
```rust
use isomorphism::BiMap;

#[derive(Clone)]
struct S {
    x: BiMap<i32, i32>,
}

fn main() {}
```

```
error[E0277]: the trait bound `isomorphism::BiMap<i32, i32>: std::clone::Clone` is not satisfied
 --> src/main.rs:5:5
  |
5 |     x: BiMap<i32, i32>,
  |     ^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `isomorphism::BiMap<i32, i32>`
  |
  = note: required by `std::clone::Clone::clone`
  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
```